### PR TITLE
Add check state pension page

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -9,6 +9,7 @@ $path: "/public/images/";
 // Take a look at in app/assets/sass/patterns/ to see which files are imported.
 @import 'patterns/check-your-answers';
 @import 'patterns/task-list';
+@import 'text';
 
 // Related items
 // (These styles will be moved to GOV.UK elements, duplicating here for now.)

--- a/app/assets/sass/text.css
+++ b/app/assets/sass/text.css
@@ -1,0 +1,4 @@
+.modified-date {
+    color: $grey-1;
+    font-size: 16px;
+}

--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'Service name goes here',
+  serviceName: 'Check your State Pension',
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/views/check-state-pension.html
+++ b/app/views/check-state-pension.html
@@ -26,7 +26,6 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-
       <h1 class="heading-xlarge">
         {% if serviceName %} {{ serviceName }} {% endif %}
       </h1>
@@ -39,7 +38,7 @@
         <li>how to increase it, if you can</li>
       </ul>
 
-      <div>
+      <div role="note" class="panel panel-border-wide">
         <p>
           This page is also available in Welsh (<a href="#">Cymraeg</a>).
         </p>
@@ -48,7 +47,7 @@
         <a href="#">The State Pension age is under review</a>
         and may change in the future.
       </p>
-      <div>
+      <div role="note" class="panel panel-border-wide">
         <p>
           You can’t use this service if you’re already getting your State Pension or if you’ve delayed (‘deferred’) claiming it.
         </p>
@@ -80,12 +79,8 @@
         Contact the <a href="#">Future Pension Centre</a> to get information about your State Pension.
       </p>
 
-      <p>
+      <p class="modified-date">
         Last updated: 18 October 2017
-      </p>
-
-      <p>
-        <a href="#">Is there anything wrong with this page?</a>
       </p>
     </div>
     <div class="column-third">

--- a/app/views/check-state-pension.html
+++ b/app/views/check-state-pension.html
@@ -1,0 +1,112 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Start page example
+{% endblock %}
+
+{% block proposition_header %}
+  <!-- blank to remove the proposition header -->
+{% endblock %}
+
+{% block header_class %}
+  <!-- blank to remove the proposition header -->
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  <div class="breadcrumbs">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="#">Working, jobs and pensions</a></li>
+      <li><a href="#">State Pension</a></li>
+    </ol>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">
+        {% if serviceName %} {{ serviceName }} {% endif %}
+      </h1>
+
+      <p>Use this service to find out:</p>
+
+      <ul class="list list-bullet">
+        <li>how much State Pension you could get (this amount is also known as your State Pension forecast)</li>
+        <li>when you can get it</li>
+        <li>how to increase it, if you can</li>
+      </ul>
+
+      <div>
+        <p>
+          This page is also available in Welsh (<a href="#">Cymraeg</a>).
+        </p>
+      </div>
+      <p>
+        <a href="#">The State Pension age is under review</a>
+        and may change in the future.
+      </p>
+      <div>
+        <p>
+          You can’t use this service if you’re already getting your State Pension or if you’ve delayed (‘deferred’) claiming it.
+        </p>
+      </div>
+      <p>
+        <a class="button button-start" href="#" role="button">Start now</a>
+      </p>
+
+      <h2 class="heading-medium">Other ways to apply</h2>
+      <p>
+        If you’ll reach <a href="#">your State Pension age</a> in more than 30
+        days, call the <a href="#">Future Pension Centre</a> and ask for a statement.
+      </p>
+      <p>
+        You can also fill in the <a href="#">BR19 application form</a> and send it in the post.
+      </p>
+      <p>
+        You’ll get your statement within 10 working days.
+      </p>
+
+      <h2 class="heading-medium">If you’re already getting your State Pension or have delayed claiming it</h2>
+      <p>
+        To get information about your State Pension, contact the <a href="#">Pension Service</a>
+        if you’re in the UK or the <a href="#">International Pension Centre</a> if you live abroad.
+      </p>
+
+      <h2 class="heading-medium">If you've worked and paid National Insurance in the Isle of Man</h2>
+      <p>
+        Contact the <a href="#">Future Pension Centre</a> to get information about your State Pension.
+      </p>
+
+      <p>
+        Last updated: 18 October 2017
+      </p>
+
+      <p>
+        <a href="#">Is there anything wrong with this page?</a>
+      </p>
+    </div>
+    <div class="column-third">
+
+      <aside class="govuk-related-items" role="complementary">
+        <h2 class="heading-medium" id="subsection-title">State pension</h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="font-xsmall">
+            <li><a href="#">The basic State Pension</a></li>
+            <li><a href="#">Check your State Pension age</a></li>
+            <li><a href="#">The new State Pension</a></li>
+            <li><a href="#">Claim your State Pension online</a></li>
+            <li><a href="#">Early retirement, your pension and benefits</a></li>
+            <li><a href="#" class="bold-xsmall">More <span class="visuallyhidden">in Subsection</span></a></li>
+          </ul>
+        </nav>
+      </aside>
+
+    </div>
+  </div>
+
+</main>
+
+{% endblock %}


### PR DESCRIPTION
We add a `check-state-pension` page based on the start page template available in `govuk_prototype_kit` and make some styling changes to get it closer to https://www.gov.uk/check-state-pension.  Note at this stage the items we have not copied over from the live page:
- Search box in the header
- "Is there anything wrong with this page?" toggle
- Footer links

Links to other GOV.UK pages have also not been included at this stage.
