### PR TITLE
Move logos to I dont have an account

### DIFF
--- a/app/assets/sass/prototype.css
+++ b/app/assets/sass/prototype.css
@@ -40,6 +40,11 @@
   max-width: 100%;
 }
 
+/**
+ *
+ * Uncomment for logos inline in radios
+ *
+
 .image-radio {
   float: right;
   user-select: none;
@@ -59,7 +64,7 @@
   }
 }
 
-@media (max-width: 400px) {
+@media (max-width: 641px) {
   .image-radio {
     margin-top: 10px;
     display: block;
@@ -67,3 +72,6 @@
     margin-left: 0;
   }
 }
+
+*
+*/

--- a/app/views/options-on-interstitial/check-state-pension-interstitial-1.html
+++ b/app/views/options-on-interstitial/check-state-pension-interstitial-1.html
@@ -39,14 +39,14 @@
           <input id="government-gateway" type="radio" name="loginoption" value="government-gateway"/>
           <label for="government-gateway">
             Government Gateway
-            <img style="max-height: 45px" class="image-radio image-responsive" src="{{ asset_path }}/images/government-gateway-logo.jpg" alt="">
+            <!-- <img style="max-height: 45px" class="image-radio image-responsive" src="{{ asset_path }}/images/government-gateway-logo.jpg" alt=""> -->
           </label>
         </div>
         <div class="multiple-choice">
           <input id="verify" type="radio" name="loginoption" value="verify"/>
           <label for="verify">
             GOV.UK Verify
-            <img style="max-height: 38px" class="image-radio image-responsive" src="{{ asset_path }}/images/govuk-verify.png" alt="">
+            <!-- <img style="max-height: 38px" class="image-radio image-responsive" src="{{ asset_path }}/images/govuk-verify.png" alt=""> -->
           </label>
         </div>
         <div class="multiple-choice">

--- a/app/views/options-on-interstitial/create-new-account-1.html
+++ b/app/views/options-on-interstitial/create-new-account-1.html
@@ -21,14 +21,33 @@
       <p>
         Lorem ipsum dolor sit amet, te vix nisl splendide signiferumque, mel reque appetere cu. Pro eu populo conceptam. Id copiosae dissentias eam. Eum ea dico exerci dicunt, mea te habeo.
       </p>
-      <a class="button" type="submit" href="https://www.tax.service.gov.uk/government-gateway-registration-frontend?accountType=individual&continue=%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend">Continue with Gateway</a>
+      <div class="inline-group">
+        <div class="inline-group--item">
+          <a class="button button--start" href="https://www.tax.service.gov.uk/government-gateway-registration-frontend?accountType=individual&continue=%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend" role="button">
+            Continue with Government Gateway
+          </a>
+        </div>
+        <div class="inline-group--item inline-group--item-aside">
+          <img style="max-height: 45px" class="image-responsive" src="{{ asset_path }}/images/government-gateway-logo.jpg" alt="">
+        </div>
+      </div>
     </div>
     <div class="column-two-thirds">
       <h2 class="heading-medium">GOV.UK Verify</h2>
       <p>
         Lorem ipsum dolor sit amet, te vix nisl splendide signiferumque, mel reque appetere cu. Pro eu populo conceptam. Id copiosae dissentias eam. Eum ea dico exerci dicunt, mea te habeo.
       </p>
-      <a class="button" type="submit" href="https://www.tax.service.gov.uk/check-your-state-pension/signin/verify">Continue with Verify</a>
+
+      <div class="inline-group">
+        <div class="inline-group--item">
+          <a class="button button--start" href="https://www.tax.service.gov.uk/check-your-state-pension/signin/verify" role="button">
+            Continue with GOV.UK Verify
+          </a>
+        </div>
+        <div class="inline-group--item inline-group--item-aside">
+          <img style="max-height: 38px" class="image-responsive" src="{{ asset_path }}/images/govuk-verify.png" alt="">
+        </div>
+      </div>
     </div>
   </div>
 </main>


### PR DESCRIPTION
We're worried the logos will be to complicated on the form
so we're moving them to the creat a new account page
which we hope we'll still see if users use them to
recognise a service.